### PR TITLE
Added phantomjs print and exit support

### DIFF
--- a/src/tink/testrunner/Reporter.hx
+++ b/src/tink/testrunner/Reporter.hx
@@ -172,6 +172,8 @@ class BasicReporter implements Reporter {
 			flash.Lib.trace(v);
 		#elseif (sys || nodejs)
 			Sys.println(v);
+		#elseif (js)
+			js.Browser.window.console.log(v);
 		#else
 			throw "Not supported yet";
 		#end

--- a/src/tink/testrunner/Runner.hx
+++ b/src/tink/testrunner/Runner.hx
@@ -16,6 +16,7 @@ class Runner {
 		#if travix travix.Logger.exit
 		#elseif (air || air3) untyped __global__["flash.desktop.NativeApplication"].nativeApplication.exit
 		#elseif (sys || nodejs) Sys.exit
+		#elseif (phantomjs) untyped __js__('phantom').exit
 		#else throw "not supported";
 		#end (result.summary().failures.length);
 	


### PR DESCRIPTION
Note that `phantomjs` is a user defined flag and not provided from including an external lib.

This allows JS to be run using the PhantomJS node module as such: `-cmd phantomjs bin/js/Tester.js`