### PR TITLE
Fixes compile error "tink_testrunner/0,6,2/src/tink/testrunner/Runner…

### DIFF
--- a/src/tink/testrunner/Runner.hx
+++ b/src/tink/testrunner/Runner.hx
@@ -12,13 +12,14 @@ using tink.CoreApi;
 
 class Runner {
 	
-	public static function exit(result:BatchResult)
+	public static function exit(result:BatchResult) {
 		#if travix travix.Logger.exit
 		#elseif (air || air3) untyped __global__["flash.desktop.NativeApplication"].nativeApplication.exit
 		#elseif (sys || nodejs) Sys.exit
 		#elseif (phantomjs) untyped __js__('phantom').exit
 		#else throw "not supported";
 		#end (result.summary().failures.length);
+	}
 	
 	public static function run(batch:Batch, ?reporter:Reporter, ?timers:TimerManager):Future<BatchResult> {
 		


### PR DESCRIPTION
….hx:21: characters 7-8 : Unexpected (".

This occurs when the "throw..." branch is reached in the Runner#exit method. This means when the platform is not travix/air/air3/sys/nodejs/phantomjs then Haxe tries to compile this conditional code:

```
public static function exit(result:BatchResult)
    throw "not supported";
    (result.summary().failures.length);
```