### PR TITLE
Add null check.

### DIFF
--- a/src/tink/testrunner/Reporter.hx
+++ b/src/tink/testrunner/Reporter.hx
@@ -90,7 +90,8 @@ class BasicReporter implements Reporter {
 	static function __init__() {
 		if(Sys.systemName() == 'Windows') { 
 			// HACK: use the "ANSICON" env var to force enable ANSI if running in PowerShell
-			var isPowerShell = Sys.getEnv('PSModulePath').split(';').length >= 3;
+			var value = Sys.getEnv('PSModulePath');
+			var isPowerShell = value != null && value.split(';').length >= 3;
 			if(isPowerShell) Sys.putEnv('ANSICON', '1');
 		}
 	}


### PR DESCRIPTION
This fixes Python on Windows built with Haxe `0e7c93e`, which throws:

```
Traceback (most recent call last):
  File "bin/default.py", line 6171, in <module>
    isPowerShell = (len(_this.split(";")) >= 3)
AttributeError: 'NoneType' object has no attribute 'split'
```